### PR TITLE
Add mechanism to allow flexible environment setup

### DIFF
--- a/godog/docker.go
+++ b/godog/docker.go
@@ -65,7 +65,7 @@ func (s *Suite) initEnv() {
 				Test: []string{"NONE"},
 			},
 			ExposedPorts: nat.PortSet{
-				nat.Port(s.servicePort[1:]): {},
+				nat.Port(s.servicePort): {},
 			},
 			Env: s.env.Vars,
 		},
@@ -73,15 +73,15 @@ func (s *Suite) initEnv() {
 			AutoRemove:  true,
 			NetworkMode: DockerNetwork,
 			PortBindings: nat.PortMap{
-				nat.Port(s.servicePort[1:]): []nat.PortBinding{{
-					HostPort: fmt.Sprintf("3%s", s.servicePort[1:]),
+				nat.Port(s.servicePort): []nat.PortBinding{{
+					HostPort: fmt.Sprintf("3%s", s.servicePort),
 				}},
 			},
 			Mounts: mounts,
 		},
 		&network.NetworkingConfig{},
 		nil,
-		fmt.Sprintf("%s-test", s.serviceName),
+		fmt.Sprintf("test-%s", s.serviceName),
 	)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Need some feature to allow flexible environment setup and run :

- Add bool flag so client can decide to initialize all the  docker-compose or not
- Add cli parser so the service host and port can be configured at runtime

I think later godogs framework should not initialize the system. It should just run tests and report result. The system setup and init should be done before running godogs.